### PR TITLE
Fixed npm run build error #issue_62

### DIFF
--- a/src/assets/sass/lbd/_navbars.scss
+++ b/src/assets/sass/lbd/_navbars.scss
@@ -65,7 +65,7 @@
     }
     
     &.fixed{
-        width: calc(100% - $sidebar-width);
+        width: calc(100% - #{$sidebar-width});
         right: 0;
         left: auto;
         border-radius: 0;


### PR DESCRIPTION
Now the command `npm run build` won't fail.

The error that used to send before was the following:
```
Failed to compile.

Lexical error on line 1: Unrecognized text.
  Erroneous area:
1: 100% - $sidebar-width
^.........^


npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! light-bootstrap-dashboard-react@1.3.0 build: `react-scripts build`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the light-bootstrap-dashboard-react@1.3.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\dcastillo\AppData\Roaming\npm-cache\_logs\2020-01-22T15_01_19_854Z-debug.log
```